### PR TITLE
Promise Cancellable Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,117 @@
 staging:[![pipeline status](https://gitlab.com/MatrixAI/open-source/js-async-cancellable/badges/staging/pipeline.svg)](https://gitlab.com/MatrixAI/open-source/js-async-cancellable/commits/staging)
 master:[![pipeline status](https://gitlab.com/MatrixAI/open-source/js-async-cancellable/badges/master/pipeline.svg)](https://gitlab.com/MatrixAI/open-source/js-async-cancellable/commits/master)
 
+This library provides the ability to cancel asynchronous tasks. Cancelling asynchronous tasks was never standardised in JavaScript. This was due to the myriad complexity of cancellation illustrated by https://github.com/tc39/proposal-cancellation:
+
+> The following are some architectural observations provided by **Dean Tribble** on the [es-discuss mailing list](https://mail.mozilla.org/pipermail/es-discuss/2015-March/041887.html):
+>
+> *Cancel requests, not results*
+>
+> Promises are like object references for async; any particular promise might
+> be returned or passed to more than one client. Usually, programmers would
+> be surprised if a returned or passed in reference just got ripped out from
+> under them *by another client*. this is especially obvious when considering
+> a library that gets a promise passed into it. Using "cancel" on the promise
+> is like having delete on object references; it's dangerous to use, and
+> unreliable to have used by others.
+>
+> *Cancellation is heterogeneous*
+>
+> It can be misleading to think about canceling a single activity. In most
+> systems, when cancellation happens, many unrelated tasks may need to be
+> cancelled for the same reason. For example, if a user hits a stop button on
+> a large incremental query after they see the first few results, what should
+> happen?
+>
+> - the async fetch of more query results should be terminated and the
+> connection closed
+> - background computation to process the remote results into renderable
+> form should be stopped
+> - rendering of not-yet rendered content should be stopped. this might
+> include retrieval of secondary content for the items no longer of interest
+> (e.g., album covers for the songs found by a complicated content search)
+> - the animation of "loading more" should be stopped, and should be
+> replaced with "user cancelled"
+> - etc.
+>
+> Some of these are different levels of abstraction, and for any non-trivial
+> application, there isn't a single piece of code that can know to terminate
+> all these activities. This kind of system also requires that cancellation
+> support is consistent across many very different types of components. But
+> if each activity takes a cancellationToken, in the above example, they just
+> get passed the one that would be cancelled if the user hits stop and the
+> right thing happens.
+>
+> *Cancellation should be smart*
+>
+> Libraries can and should be smart about how they cancel. In the case of an
+> async query, once the result of a query from the server has come back, it
+> may make sense to finish parsing and caching it rather than just
+> reflexively discarding it. In the case of a brokerage system, for example,
+> the round trip to the servers to get recent data is the expensive part.
+> Once that's been kicked off and a result is coming back, having it
+> available in a local cache in case the user asks again is efficient. If the
+> application spawned another worker, it may be more efficient to let the
+> worker complete (so that you can reuse it) rather than abruptly terminate
+> it (requiring discarding of the running worker and cached state).
+>
+> *Cancellation is a race*
+>
+> In an async system, new activities may be getting continuously scheduled by
+> asks that are themselves scheduled but not currently running. The act of
+> cancelling needs to run in this environment. When cancel starts, you can
+> think of it as a signal racing out to catch up with all the computations
+> launched to achieve the now-cancelled objective. Some of those may choose
+> to complete (see the caching example above). Some may potentially keep
+> launching more work before that work itself gets signaled (yeah it's a bug
+> but people write buggy code). In an async system, cancellation is not
+> prompt. Thus, it's infeasible to ask "has cancellation finished?" because
+> that's not a well defined state. Indeed, there can be code scheduled that
+> should and does not get cancelled (e.g., the result processor for a pub/sub
+> system), but that schedules work that will be cancelled (parse the
+> publication of an update to the now-cancelled query).
+>
+> *Cancellation is "don't care"*
+>
+> Because smart cancellation sometimes doesn't stop anything and in an async
+> environment, cancellation is racing with progress, it is at most "best
+> efforts". When a set of computations are cancelled, the party canceling the
+> activities is saying "I no longer care whether this completes". That is
+> importantly different from saying "I want to prevent this from completing".
+> The former is broadly usable resource reduction. The latter is only
+> usefully achieved in systems with expensive engineering around atomicity
+> and transactions. It was amazing how much simpler cancellation logic
+> becomes when it's "don't care".
+>
+> *Cancellation requires separation of concerns*
+>
+> In the pattern where more than one thing gets cancelled, the source of the
+> cancellation is rarely one of the things to be cancelled. It would be a
+> surprise if a library called for a cancellable activity (load this image)
+> cancelled an unrelated server query just because they cared about the same
+> cancellation event. I find it interesting that the separation between
+> cancellation token and cancellation source mirrors that separation between
+> a promise and it's resolver.
+>
+> *Cancellation recovery is transient*
+>
+> As a task progresses, the cleanup action may change. In the example above,
+> if the data table requests more results upon scrolling, it's cancellation
+> behavior when there's an outstanding query for more data is likely to be
+> quite different than when it's got everything it needs displayed for the
+> current page. That's the reason why the "register" method returns a
+> capability to unregister the action.
+
+This library attempts to address each concern.
+
+1. Cancel requests, not results - cancellation only affects the immediate promise and all downstream promises, not upstream promises unless explicitly configured via a signal handler
+2. Cancellation is heterogenous - cancellation can be customised through a signal handler or an `AbortController`, this allows the user to define how cancellation should propagate through the application
+3. Cancellation should be smart - during the `PromiseCancellable.then` binding, both the the fulfilled and rejected handler takes the `signal: AbortSignal`, here it is possible to customise the logic of fulfillment and rejection depending on the situation, therefore cancellation can be as smart as you want it to be
+4. Cancellation is a race - this is achieved by using `AbortSignal`, one cannot ask if cancellation is finished, it is purely an event driven system
+5. Cancellation is "don't care" - `PromiseCancellation.cancel` is purely advisory, the default behaviour is that the immediate promise is rejected early, however this can be customised, therefore the default intention is that the promise can be rejected with the cancellation reason, and means you don't care about the result anymore, it does not imply anything stronger than this
+6. Cancellation requires separation of concerns - by supplying a signal handler or abort controller, it is possible to separate any concern
+7. Cancellation recovery is transient - during the `PromiseCancellable.then`, `PromiseCancellable.catch` and `PromiseCancellable.finally`, the signal is passed in, it is possible to change how you cancel depending on what the current situation is.
+
 ## Installation
 
 ```sh

--- a/src/PromiseCancellable.ts
+++ b/src/PromiseCancellable.ts
@@ -164,7 +164,7 @@ class PromiseCancellable<T> extends Promise<T> {
             signalHandled = true;
           }
           return Reflect.set(target, prop, value);
-        }
+        },
       });
       signalHandled = false;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,4 +2,8 @@ type PromiseCancellableController =
   | ((signal: AbortSignal) => void)
   | AbortController;
 
-export type { PromiseCancellableController };
+type PromiseLikeCancellable<T> = PromiseLike<T> & {
+  cancel(reason?: any): void;
+};
+
+export type { PromiseCancellableController, PromiseLikeCancellable };

--- a/tests/PromiseCancellable.test.ts
+++ b/tests/PromiseCancellable.test.ts
@@ -17,7 +17,7 @@ describe(PromiseCancellable.name, () => {
               reject(new Error('Aborted F', { cause: ctx.signal!.reason }));
             }
           },
-          { once: true }
+          { once: true },
         );
       }
     });
@@ -283,7 +283,6 @@ describe(PromiseCancellable.name, () => {
       });
       p3.cancel('P3 abort');
       await expect(p3).rejects.toBe('P1 abort');
-      // await expect(p3).rejects.toBe('P2 abort beginning');
       await expect(p1).rejects.toBe('P1 abort');
       expect(p2Resolve).not.toBeCalled();
       expect(p2Reject).toBeCalledWith('P1 abort', expect.any(AbortSignal));
@@ -543,7 +542,7 @@ describe(PromiseCancellable.name, () => {
         Promise.resolve(1),
         PromiseCancellable.resolve(2),
         3,
-        4
+        4,
       ]);
       const results = await p;
       expect(results).toStrictEqual([1, 2, 3, 4]);
@@ -553,14 +552,14 @@ describe(PromiseCancellable.name, () => {
         Promise.reject(1),
         PromiseCancellable.resolve(2),
         3,
-        4
+        4,
       ]);
       await expect(p1).rejects.toBe(1);
       const p2 = PromiseCancellable.all([
         Promise.resolve(1),
         PromiseCancellable.reject(2),
         3,
-        4
+        4,
       ]);
       await expect(p2).rejects.toBe(2);
     });
@@ -572,11 +571,7 @@ describe(PromiseCancellable.name, () => {
           reject('P1 abort');
         };
       });
-      const p2 = PromiseCancellable.all([
-        PromiseCancellable.all([
-          p1
-        ])
-      ]);
+      const p2 = PromiseCancellable.all([PromiseCancellable.all([p1])]);
       await expect(p2).rejects.toBe('P1 reject');
     });
     test('default cancellation is early rejection', async () => {
@@ -594,26 +589,32 @@ describe(PromiseCancellable.name, () => {
     });
     test('custom signal handler', async () => {
       const abortController = new AbortController();
-      const p = PromiseCancellable.all([
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-      ], (signal) => {
-        signal.onabort = () => {
-          abortController.abort(signal.reason);
-        };
-      });
+      const p = PromiseCancellable.all(
+        [
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+        ],
+        (signal) => {
+          signal.onabort = () => {
+            abortController.abort(signal.reason);
+          };
+        },
+      );
       p.cancel('P abort');
       await expect(p).rejects.toThrow('Aborted F');
       await expect(p).rejects.toHaveProperty('cause', 'P abort');
     });
     test('custom abort controller', async () => {
       const abortController = new AbortController();
-      const p = PromiseCancellable.all([
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-      ], abortController);
+      const p = PromiseCancellable.all(
+        [
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+        ],
+        abortController,
+      );
       p.cancel('P abort');
       await expect(p).rejects.toThrow('Aborted F');
       await expect(p).rejects.toHaveProperty('cause', 'P abort');
@@ -625,25 +626,25 @@ describe(PromiseCancellable.name, () => {
         Promise.resolve(1),
         PromiseCancellable.resolve(2),
         3,
-        4
+        4,
       ]);
       const results = await p;
       expect(results).toStrictEqual([
         {
           status: 'fulfilled',
-          value: 1
+          value: 1,
         },
         {
           status: 'fulfilled',
-          value: 2
+          value: 2,
         },
         {
           status: 'fulfilled',
-          value: 3
+          value: 3,
         },
         {
           status: 'fulfilled',
-          value: 4
+          value: 4,
         },
       ]);
     });
@@ -652,25 +653,25 @@ describe(PromiseCancellable.name, () => {
         Promise.reject(1),
         PromiseCancellable.reject(2),
         3,
-        4
+        4,
       ]);
       const results = await p;
       expect(results).toStrictEqual([
         {
           status: 'rejected',
-          reason: 1
+          reason: 1,
         },
         {
           status: 'rejected',
-          reason: 2
+          reason: 2,
         },
         {
           status: 'fulfilled',
-          value: 3
+          value: 3,
         },
         {
           status: 'fulfilled',
-          value: 4
+          value: 4,
         },
       ]);
     });
@@ -683,17 +684,19 @@ describe(PromiseCancellable.name, () => {
         };
       });
       const p2 = PromiseCancellable.allSettled([
-        PromiseCancellable.allSettled([
-          p1
-        ])
+        PromiseCancellable.allSettled([p1]),
       ]);
-      await expect(p2).resolves.toStrictEqual([{
-        status: 'fulfilled',
-        value: [{
-          status: 'rejected',
-          reason: 'P1 reject'
-        }]
-      }]);
+      await expect(p2).resolves.toStrictEqual([
+        {
+          status: 'fulfilled',
+          value: [
+            {
+              status: 'rejected',
+              reason: 'P1 reject',
+            },
+          ],
+        },
+      ]);
     });
     test('default cancellation is early rejection', async () => {
       const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
@@ -710,15 +713,18 @@ describe(PromiseCancellable.name, () => {
     });
     test('custom signal handler', async () => {
       const abortController = new AbortController();
-      const p = PromiseCancellable.allSettled([
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-      ], (signal) => {
-        signal.onabort = () => {
-          abortController.abort(signal.reason);
-        };
-      });
+      const p = PromiseCancellable.allSettled(
+        [
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+        ],
+        (signal) => {
+          signal.onabort = () => {
+            abortController.abort(signal.reason);
+          };
+        },
+      );
       p.cancel('P abort');
       const results = await p;
       expect(results).toMatchObject([
@@ -727,34 +733,37 @@ describe(PromiseCancellable.name, () => {
           reason: expect.objectContaining({
             name: 'Error',
             message: 'Aborted F',
-            cause: 'P abort'
-          })
+            cause: 'P abort',
+          }),
         },
         {
           status: 'rejected',
           reason: expect.objectContaining({
             name: 'Error',
             message: 'Aborted F',
-            cause: 'P abort'
-          })
+            cause: 'P abort',
+          }),
         },
         {
           status: 'rejected',
           reason: expect.objectContaining({
             name: 'Error',
             message: 'Aborted F',
-            cause: 'P abort'
-          })
+            cause: 'P abort',
+          }),
         },
       ]);
     });
     test('custom abort controller', async () => {
       const abortController = new AbortController();
-      const p = PromiseCancellable.allSettled([
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-      ], abortController);
+      const p = PromiseCancellable.allSettled(
+        [
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+        ],
+        abortController,
+      );
       p.cancel('P abort');
       const results = await p;
       expect(results).toMatchObject([
@@ -763,24 +772,24 @@ describe(PromiseCancellable.name, () => {
           reason: expect.objectContaining({
             name: 'Error',
             message: 'Aborted F',
-            cause: 'P abort'
-          })
+            cause: 'P abort',
+          }),
         },
         {
           status: 'rejected',
           reason: expect.objectContaining({
             name: 'Error',
             message: 'Aborted F',
-            cause: 'P abort'
-          })
+            cause: 'P abort',
+          }),
         },
         {
           status: 'rejected',
           reason: expect.objectContaining({
             name: 'Error',
             message: 'Aborted F',
-            cause: 'P abort'
-          })
+            cause: 'P abort',
+          }),
         },
       ]);
     });
@@ -791,9 +800,9 @@ describe(PromiseCancellable.name, () => {
         Promise.resolve(1),
         PromiseCancellable.resolve(2),
         3,
-        4
+        4,
       ]);
-      expect([1,2,3,4]).toContain(await p1);
+      expect([1, 2, 3, 4]).toContain(await p1);
       const p2 = PromiseCancellable.race([
         new Promise((resolve) => setTimeout(() => resolve(1), 100)),
         new Promise((resolve) => setTimeout(() => resolve(2), 50)),
@@ -825,11 +834,7 @@ describe(PromiseCancellable.name, () => {
           reject('P1 abort');
         };
       });
-      const p2 = PromiseCancellable.race([
-        PromiseCancellable.race([
-          p1
-        ])
-      ]);
+      const p2 = PromiseCancellable.race([PromiseCancellable.race([p1])]);
       await expect(p2).rejects.toBe('P1 reject');
     });
     test('default cancellation is early rejection', async () => {
@@ -847,56 +852,63 @@ describe(PromiseCancellable.name, () => {
     });
     test('custom signal handler', async () => {
       const abortController = new AbortController();
-      const p = PromiseCancellable.race([
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-      ], (signal) => {
-        signal.onabort = () => {
-          abortController.abort(signal.reason);
-        };
-      });
+      const p = PromiseCancellable.race(
+        [
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+        ],
+        (signal) => {
+          signal.onabort = () => {
+            abortController.abort(signal.reason);
+          };
+        },
+      );
       p.cancel('P abort');
       await expect(p).rejects.toThrow('Aborted F');
       await expect(p).rejects.toHaveProperty('cause', 'P abort');
     });
     test('custom abort controller', async () => {
       const abortController = new AbortController();
-      const p = PromiseCancellable.race([
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-      ], abortController);
+      const p = PromiseCancellable.race(
+        [
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+        ],
+        abortController,
+      );
       p.cancel('P abort');
       await expect(p).rejects.toThrow('Aborted F');
       await expect(p).rejects.toHaveProperty('cause', 'P abort');
     });
     test('racing signal handler', async () => {
-      const racer = jest.fn().mockImplementation((name: string, delay: number) => {
-        return new PromiseCancellable<string>((resolve, reject, signal) => {
-          if (signal.aborted) {
-            reject('racer abort beginning');
-            return;
-          }
-          const timeout = setTimeout(() => resolve(`racer ${name} result`), delay);
-          signal.addEventListener(
-            'abort',
-            () => {
-              clearTimeout(timeout);
-              reject('racer abort during');
-            },
-            { once: true }
-          );
+      const racer = jest
+        .fn()
+        .mockImplementation((name: string, delay: number) => {
+          return new PromiseCancellable<string>((resolve, reject, signal) => {
+            if (signal.aborted) {
+              reject('racer abort beginning');
+              return;
+            }
+            const timeout = setTimeout(
+              () => resolve(`racer ${name} result`),
+              delay,
+            );
+            signal.addEventListener(
+              'abort',
+              () => {
+                clearTimeout(timeout);
+                reject('racer abort during');
+              },
+              { once: true },
+            );
+          });
         });
-      });
-      const race = [
-        racer('1', 50),
-        racer('2', 100),
-        racer('3', 150),
-      ];
+      const race = [racer('1', 50), racer('2', 100), racer('3', 150)];
       const p = PromiseCancellable.race(race, (signal) => {
         signal.onabort = () => {
-          race.map(r => r.cancel(signal.reason));
+          race.map((r) => r.cancel(signal.reason));
         };
       });
       const result = await p;
@@ -912,10 +924,10 @@ describe(PromiseCancellable.name, () => {
         Promise.resolve(1),
         PromiseCancellable.resolve(2),
         3,
-        Promise.reject(4)
+        Promise.reject(4),
       ]);
       const result = await p1;
-      expect([1,2,3]).toContain(result);
+      expect([1, 2, 3]).toContain(result);
       expect(result).not.toBe(4);
       const p2 = PromiseCancellable.any([
         new Promise((resolve) => setTimeout(() => resolve(1), 100)),
@@ -946,18 +958,14 @@ describe(PromiseCancellable.name, () => {
           reject('P1 abort');
         };
       });
-      const p2 = PromiseCancellable.any([
-        PromiseCancellable.any([
-          p1
-        ])
-      ]);
+      const p2 = PromiseCancellable.any([PromiseCancellable.any([p1])]);
       await expect(p2).rejects.toThrow(AggregateError);
       await expect(p2).rejects.toMatchObject({
         errors: [
           {
-            errors: ['P1 reject']
-          }
-        ]
+            errors: ['P1 reject'],
+          },
+        ],
       });
     });
     test('default cancellation is early rejection', async () => {
@@ -975,58 +983,64 @@ describe(PromiseCancellable.name, () => {
     });
     test('custom signal handler', async () => {
       const abortController = new AbortController();
-      const p = PromiseCancellable.any([
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-      ], (signal) => {
-        signal.onabort = () => {
-          abortController.abort(signal.reason);
-        };
-      });
+      const p = PromiseCancellable.any(
+        [
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+        ],
+        (signal) => {
+          signal.onabort = () => {
+            abortController.abort(signal.reason);
+          };
+        },
+      );
       p.cancel('P abort');
       await expect(p).rejects.toThrow(AggregateError);
       await expect(p).rejects.toMatchObject({
         errors: [
           {
             message: 'Aborted F',
-            cause: 'P abort'
+            cause: 'P abort',
           },
           {
             message: 'Aborted F',
-            cause: 'P abort'
+            cause: 'P abort',
           },
           {
             message: 'Aborted F',
-            cause: 'P abort'
-          }
-        ]
+            cause: 'P abort',
+          },
+        ],
       });
     });
     test('custom abort controller', async () => {
       const abortController = new AbortController();
-      const p = PromiseCancellable.any([
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-        f({ signal: abortController.signal }),
-      ], abortController);
+      const p = PromiseCancellable.any(
+        [
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+          f({ signal: abortController.signal }),
+        ],
+        abortController,
+      );
       p.cancel('P abort');
       await expect(p).rejects.toThrow(AggregateError);
       await expect(p).rejects.toMatchObject({
         errors: [
           {
             message: 'Aborted F',
-            cause: 'P abort'
+            cause: 'P abort',
           },
           {
             message: 'Aborted F',
-            cause: 'P abort'
+            cause: 'P abort',
           },
           {
             message: 'Aborted F',
-            cause: 'P abort'
-          }
-        ]
+            cause: 'P abort',
+          },
+        ],
       });
     });
   });

--- a/tests/PromiseCancellable.test.ts
+++ b/tests/PromiseCancellable.test.ts
@@ -23,6 +23,13 @@ describe(PromiseCancellable.name, () => {
     });
   }
   describe('new PromiseCancellable', () => {
+    test('default is early rejection', async () => {
+      const pC = new PromiseCancellable<void>((resolve) => {
+        setTimeout(() => resolve(), 100);
+      });
+      pC.cancel('cancellation');
+      await expect(pC).rejects.toBe('cancellation');
+    });
     test('constructing promise cancellable', async () => {
       let timeout: ReturnType<typeof setTimeout> | undefined;
       const pC = new PromiseCancellable<void>((resolve, reject, signal) => {
@@ -276,6 +283,7 @@ describe(PromiseCancellable.name, () => {
       });
       p3.cancel('P3 abort');
       await expect(p3).rejects.toBe('P1 abort');
+      // await expect(p3).rejects.toBe('P2 abort beginning');
       await expect(p1).rejects.toBe('P1 abort');
       expect(p2Resolve).not.toBeCalled();
       expect(p2Reject).toBeCalledWith('P1 abort', expect.any(AbortSignal));

--- a/tests/PromiseCancellable.test.ts
+++ b/tests/PromiseCancellable.test.ts
@@ -1,19 +1,1025 @@
 import PromiseCancellable from '@/PromiseCancellable';
 
 describe(PromiseCancellable.name, () => {
-  test('cancel promise', async () => {
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-    const pC = new PromiseCancellable<void>((resolve, reject, signal) => {
-      timeout = setTimeout(() => resolve(), 5000);
-      signal.onabort = () => {
-        clearTimeout(timeout);
-        timeout = undefined;
-        reject(signal.reason);
-      };
+  function f(ctx?: { signal?: AbortSignal }): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        resolve('Result');
+      }, 100);
+      if (ctx?.signal != null) {
+        ctx.signal.addEventListener(
+          'abort',
+          () => {
+            clearTimeout(timeout);
+            if (ctx.signal!.reason === undefined) {
+              reject(new Error('Aborted F'));
+            } else {
+              reject(new Error('Aborted F', { cause: ctx.signal!.reason }));
+            }
+          },
+          { once: true }
+        );
+      }
     });
-    expect(timeout).toBeDefined();
-    pC.cancel('cancellation');
-    await expect(pC).rejects.toBe('cancellation');
-    expect(timeout).toBeUndefined();
+  }
+  describe('new PromiseCancellable', () => {
+    test('constructing promise cancellable', async () => {
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const pC = new PromiseCancellable<void>((resolve, reject, signal) => {
+        timeout = setTimeout(() => resolve(), 5000);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          timeout = undefined;
+          reject(signal.reason);
+        };
+      });
+      expect(timeout).toBeDefined();
+      pC.cancel('cancellation');
+      expect(timeout).toBeUndefined();
+      await expect(pC).rejects.toBe('cancellation');
+    });
+    test('cancelling cancellable function with signal', async () => {
+      const pC = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const p = f({ signal });
+        void p.then(resolve, reject);
+      });
+      const e = new Error('Abort Reason');
+      pC.cancel(e);
+      await expect(pC).rejects.toThrow('Aborted F');
+      await expect(pC).rejects.toHaveProperty('cause', e);
+    });
+  });
+  describe('PromiseCancellable.resolve & PromiseCancellable.reject', () => {
+    test('resolve regular values', async () => {
+      const p = PromiseCancellable.resolve(1);
+      await expect(p).resolves.toBe(1);
+    });
+    test('rejecting regular values', async () => {
+      const p = PromiseCancellable.reject(1);
+      await expect(p).rejects.toBe(1);
+    });
+    test('resolve promises', async () => {
+      // Resolving an existing `PromiseCancellable` returns the same object
+      const p1 = PromiseCancellable.resolve(1);
+      const p2 = PromiseCancellable.resolve(p1);
+      expect(p2).toBe(p1);
+      await expect(p2).resolves.toBe(1);
+      // Resolving an existing `Promise` ensures a wrapper
+      const p3 = Promise.resolve(1);
+      const p4 = PromiseCancellable.resolve(p3);
+      expect(p4).not.toBe(p3);
+    });
+    test('rejecting promises', async () => {
+      const p1 = PromiseCancellable.resolve(1);
+      const p2 = PromiseCancellable.reject(p1);
+      expect(p1).not.toBe(p2);
+      await expect(p2).rejects.toBe(p1);
+      await expect(p1).resolves.toBe(1);
+    });
+    test('cancelling after resolution is a noop', async () => {
+      const p = PromiseCancellable.resolve(1);
+      p.cancel(2);
+      await expect(p).resolves.toBe(1);
+    });
+    test('cancelling after rejection is a noop', async () => {
+      const p = PromiseCancellable.reject(1);
+      p.cancel(2);
+      await expect(p).rejects.toBe(1);
+    });
+  });
+  describe('PromiseCancellable.from', () => {
+    test('default cancellation is early rejection', async () => {
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      const p = new Promise<void>((resolve) => {
+        timeout = setTimeout(() => {
+          timeout = undefined;
+          resolve();
+        }, 10);
+      });
+      const pC = PromiseCancellable.from(p);
+      const e = new Error('early rejection');
+      pC.cancel(e);
+      expect(timeout).toBeDefined();
+      await expect(pC).rejects.toThrow(e);
+    });
+    test('from a cancellable function with abort controller', async () => {
+      const abortController = new AbortController();
+      const p = f({ signal: abortController.signal });
+      const pC = PromiseCancellable.from(p, abortController);
+      const e = new Error('Abort Reason');
+      pC.cancel(e);
+      await expect(pC).rejects.toThrow('Aborted F');
+      await expect(pC).rejects.toHaveProperty('cause', e);
+    });
+    test('from a cancellable function with default early rejection', async () => {
+      const abortController = new AbortController();
+      const p = f({ signal: abortController.signal });
+      const pC = PromiseCancellable.from(p);
+      pC.cancel();
+      await expect(pC).rejects.toBeUndefined();
+      await expect(p).resolves.toBe('Result');
+    });
+  });
+  describe('PromiseCancellable.then', () => {
+    test('p3 = p1.then(() => p2) - p2 rejection propagates to p3', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => resolve('P1 result'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      let p2: Promise<string>;
+      const p2Resolve = jest.fn().mockImplementation(() => {
+        p2 = new Promise<string>((resolve, reject) => {
+          reject('P2 abort beginning');
+        });
+        return p2;
+      });
+      const p2Reject = jest.fn().mockImplementation((r) => {
+        throw r;
+      });
+      const p3 = p1.then(p2Resolve, p2Reject);
+      await expect(p3).rejects.toBe('P2 abort beginning');
+      await expect(p1).resolves.toBe('P1 result');
+      expect(p2Resolve).toBeCalledWith('P1 result', expect.any(AbortSignal));
+      expect(p2Reject).not.toBeCalled();
+      await expect(p2!).rejects.toBe('P2 abort beginning');
+    });
+    test('p3 = p1.then(() => p2) - p3 cancellation results in early rejection of p3 and p2', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => resolve('P1 result'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      let p2: Promise<string>;
+      const p2Resolve = jest.fn().mockImplementation((value, signal) => {
+        // This is called because `p3` cancellation is an early rejection
+        // of `p3`, while `p1` is still running `p2` is bound to `p1`
+        p2 = new Promise<string>((resolve, reject) => {
+          expect(signal.aborted).toBe(true);
+          if (signal.aborted) {
+            reject('P2 abort beginning');
+            return;
+          }
+          const timeout = setTimeout(() => {
+            resolve(`${value} P2 result`);
+          }, 100);
+          signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timeout);
+              reject('P2 abort during');
+            },
+            { once: true },
+          );
+        });
+        return p2;
+      });
+      const p2Reject = jest.fn().mockImplementation((r) => {
+        throw r;
+      });
+      const p3 = p1.then(p2Resolve, p2Reject);
+      p3.cancel('P3 abort');
+      await expect(p3).rejects.toBe('P3 abort');
+      await expect(p1).resolves.toBe('P1 result');
+      expect(p2Resolve).toBeCalledWith('P1 result', expect.any(AbortSignal));
+      expect(p2Reject).not.toBeCalled();
+      await expect(p2!).rejects.toBe('P2 abort beginning');
+    });
+    test('p3 = p1.then(() => p2) - delayed p3 cancellation results in early rejection of p3 and late rejection of p2', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => resolve('P1 result'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      let p2: Promise<string>;
+      const p2Resolve = jest.fn().mockImplementation((value, signal) => {
+        p2 = new Promise<string>((resolve, reject) => {
+          // This runs earlier than the cancellation of `p3`
+          // therefore it is not yet aborted
+          expect(signal.aborted).toBe(false);
+          if (signal.aborted) {
+            reject('P2 abort beginning');
+            return;
+          }
+          const timeout = setTimeout(() => {
+            resolve(`${value} P2 result`);
+          }, 100);
+          signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timeout);
+              reject('P2 abort during');
+            },
+            { once: true },
+          );
+        });
+        return p2;
+      });
+      const p2Reject = jest.fn().mockImplementation((r) => {
+        throw r;
+      });
+      const p3 = p1.then(p2Resolve, p2Reject);
+      await expect(p1).resolves.toBe('P1 result');
+      expect(p2Resolve).toBeCalledWith('P1 result', expect.any(AbortSignal));
+      expect(p2Reject).not.toBeCalled();
+      p3.cancel('P3 abort');
+      await expect(p3).rejects.toBe('P3 abort');
+      await expect(p2!).rejects.toBe('P2 abort during');
+    });
+    test('p3 = p1.then(() => p2) - p3 cancellation chained to p1 cancellation propagates rejection', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => resolve('P1 result'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      let p2: Promise<string>;
+      const p2Resolve = jest.fn().mockImplementation((value, signal) => {
+        p2 = new PromiseCancellable<string>((resolve, reject) => {
+          if (signal.aborted) {
+            reject('P2 abort beginning');
+            return;
+          }
+          const timeout = setTimeout(() => {
+            resolve(`${value} P2 result`);
+          }, 100);
+          signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timeout);
+              reject('P2 abort during');
+            },
+            { once: true },
+          );
+        });
+        return p2;
+      });
+      const p2Reject = jest.fn().mockImplementation((reason, signal) => {
+        expect(signal.aborted).toBe(true);
+        throw reason;
+      });
+      const p3 = p1.then(p2Resolve, p2Reject, (signal) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            p1.cancel(signal.reason);
+          },
+          { once: true },
+        );
+      });
+      p3.cancel('P3 abort');
+      await expect(p3).rejects.toBe('P1 abort');
+      await expect(p1).rejects.toBe('P1 abort');
+      expect(p2Resolve).not.toBeCalled();
+      expect(p2Reject).toBeCalledWith('P1 abort', expect.any(AbortSignal));
+      expect(p2!).toBeUndefined();
+    });
+  });
+  describe('PromiseCancellable.catch', () => {
+    test('p3 = p1.catch(() => p2) - rejection propagates p1 to p2 to p3', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject) => {
+        setTimeout(() => reject('P1 reject'), 100);
+      });
+      let p2: Promise<string>;
+      const p2Catch = jest.fn().mockImplementation((reason, signal) => {
+        expect(signal.aborted).toBe(false);
+        p2 = new Promise<string>((resolve, reject) => {
+          reject('P2 abort beginning');
+        });
+        return p2;
+      });
+      const p3 = p1.catch(p2Catch);
+      await expect(p3).rejects.toBe('P2 abort beginning');
+      await expect(p1).rejects.toBe('P1 reject');
+      expect(p2Catch).toBeCalledWith('P1 reject', expect.any(AbortSignal));
+      await expect(p2!).rejects.toBe('P2 abort beginning');
+    });
+    test('p3 = p1.catch(() => p2) - resolution propagates p1 to p3', async () => {
+      const p1 = new PromiseCancellable<string>((resolve) => {
+        setTimeout(() => resolve('P1 result'), 100);
+      });
+      let p2: PromiseCancellable<string>;
+      const p2Catch = jest.fn().mockImplementation(() => {
+        p2 = new PromiseCancellable<string>((resolve, reject) => {
+          reject('P2 abort beginning');
+        });
+        return p2;
+      });
+      const p3 = p1.catch(p2Catch);
+      await expect(p3).resolves.toBe('P1 result');
+      await expect(p1).resolves.toBe('P1 result');
+      expect(p2Catch).not.toBeCalled();
+      expect(p2!).toBeUndefined();
+    });
+    test('p3 = p1.catch(() => p2) - p3 cancellation results in early rejection of p3 and p2', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject) => {
+        setTimeout(() => reject('P1 reject'), 100);
+      });
+      let p2: Promise<string>;
+      const p2Catch = jest.fn().mockImplementation((reason, signal) => {
+        expect(signal.aborted).toBe(true);
+        p2 = new Promise<string>((resolve, reject) => {
+          if (signal.aborted) {
+            reject('P2 abort beginning');
+            return;
+          }
+          reject('P2 abort during');
+        });
+        return p2;
+      });
+      const p3 = p1.catch(p2Catch);
+      p3.cancel('P3 abort');
+      await expect(p3).rejects.toBe('P3 abort');
+      await expect(p1).rejects.toBe('P1 reject');
+      expect(p2Catch).toBeCalledWith('P1 reject', expect.any(AbortSignal));
+      await expect(p2!).rejects.toBe('P2 abort beginning');
+    });
+    test('p3 = p1.catch(() => p2) - delayed p3 cancellation results in early rejection of p3 and late rejection of p2', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject) => {
+        setTimeout(() => reject('P1 reject'), 100);
+      });
+      let p2: Promise<string>;
+      const p2Catch = jest.fn().mockImplementation((reason, signal) => {
+        expect(signal.aborted).toBe(false);
+        p2 = new Promise<string>((resolve, reject) => {
+          if (signal.aborted) {
+            reject('P2 abort beginning');
+            return;
+          }
+          const timeout = setTimeout(() => resolve('P2 result'), 100);
+          signal.onabort = () => {
+            clearTimeout(timeout);
+            reject('P2 abort during');
+          };
+        });
+        return p2;
+      });
+      const p3 = p1.catch(p2Catch);
+      await expect(p1).rejects.toBe('P1 reject');
+      expect(p2Catch).toBeCalledWith('P1 reject', expect.any(AbortSignal));
+      p3.cancel('P3 abort');
+      await expect(p3).rejects.toBe('P3 abort');
+      await expect(p2!).rejects.toBe('P2 abort during');
+    });
+    test('p3 = p1.catch(() => p2) - p3 cancellation chained to p1 cancellation propagates rejection', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => resolve('P1 result'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      let p2: Promise<string>;
+      const p2Catch = jest.fn().mockImplementation((reason, signal) => {
+        expect(signal.aborted).toBe(true);
+        p2 = new Promise<string>((resolve, reject) => {
+          if (signal.aborted) {
+            reject('P2 abort beginning');
+            return;
+          }
+          const timeout = setTimeout(() => resolve('P2 result'), 100);
+          signal.onabort = () => {
+            clearTimeout(timeout);
+            reject('P2 abort during');
+          };
+        });
+        return p2;
+      });
+      const p3 = p1.catch(p2Catch, (signal) => {
+        signal.onabort = () => {
+          p1.cancel(signal.reason);
+        };
+      });
+      p3.cancel('P3 abort');
+      await expect(p3).rejects.toBe('P2 abort beginning');
+      await expect(p1).rejects.toBe('P1 abort');
+      expect(p2Catch).toBeCalledWith('P1 abort', expect.any(AbortSignal));
+      await expect(p2!).rejects.toBe('P2 abort beginning');
+    });
+  });
+  describe('PromiseCancellable.finally', () => {
+    test('p3 = p1.finally(() => p2) - p2 cannot affect the resolved result of p1', async () => {
+      const p1 = new PromiseCancellable<string>((resolve) => {
+        setTimeout(() => resolve('P1 result'), 100);
+      });
+      let p2: PromiseCancellable<string>;
+      const p2Finally = jest.fn().mockImplementation(() => {
+        p2 = new PromiseCancellable<string>((resolve) => {
+          setTimeout(() => resolve('P2 result'), 100);
+        });
+        return p2;
+      });
+      const p3 = p1.finally(p2Finally);
+      await expect(p3).resolves.toBe('P1 result');
+      expect(p2Finally).toBeCalledWith(expect.any(AbortSignal));
+      await expect(p2!).resolves.toBe('P2 result');
+    });
+    test('p3 = p1.finally(() => p2) - rejection propagates p1 to p2 to p3', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject) => {
+        setTimeout(() => reject('P1 reject'), 100);
+      });
+      let p2: Promise<string>;
+      const p2Finally = jest.fn().mockImplementation((signal) => {
+        expect(signal.aborted).toBe(false);
+        p2 = new Promise<string>((resolve, reject) => {
+          reject('P2 abort beginning');
+        });
+        return p2;
+      });
+      const p3 = p1.finally(p2Finally);
+      await expect(p3).rejects.toBe('P2 abort beginning');
+      await expect(p1).rejects.toBe('P1 reject');
+      expect(p2Finally).toBeCalledWith(expect.any(AbortSignal));
+      await expect(p2!).rejects.toBe('P2 abort beginning');
+    });
+    test('p3 = p1.finally(() => p2) - p3 cancellation results in early rejection of p3 and p2', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject) => {
+        setTimeout(() => reject('P1 reject'), 100);
+      });
+      let p2: PromiseCancellable<string>;
+      const p2Finally = jest.fn().mockImplementation((signal) => {
+        expect(signal.aborted).toBe(true);
+        p2 = new PromiseCancellable<string>((resolve, reject) => {
+          if (signal.aborted) {
+            reject('P2 abort beginning');
+            return;
+          }
+          const timeout = setTimeout(() => reject('P2 reject'), 100);
+          signal.onabort = () => {
+            clearTimeout(timeout);
+            reject('P2 abort during');
+          };
+        });
+        return p2;
+      });
+      const p3 = p1.finally(p2Finally);
+      p3.cancel('P3 abort');
+      await expect(p3).rejects.toBe('P3 abort');
+      await expect(p1).rejects.toBe('P1 reject');
+      expect(p2Finally).toBeCalledWith(expect.any(AbortSignal));
+      await expect(p2!).rejects.toBe('P2 abort beginning');
+    });
+    test('p3 = p1.finally(() => p2) - delayed p3 cancellation results in early rejection of p3 and late rejection of p2', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject) => {
+        setTimeout(() => reject('P1 reject'), 100);
+      });
+      let p2: PromiseCancellable<string>;
+      const p2Finally = jest.fn().mockImplementation((signal) => {
+        expect(signal.aborted).toBe(false);
+        p2 = new PromiseCancellable<string>((resolve, reject) => {
+          if (signal.aborted) {
+            reject('P2 abort beginning');
+            return;
+          }
+          const timeout = setTimeout(() => reject('P2 reject'), 100);
+          signal.onabort = () => {
+            clearTimeout(timeout);
+            reject('P2 abort during');
+          };
+        });
+        return p2;
+      });
+      const p3 = p1.finally(p2Finally);
+      await expect(p1).rejects.toBe('P1 reject');
+      expect(p2Finally).toBeCalledWith(expect.any(AbortSignal));
+      p3.cancel('P3 abort');
+      await expect(p3).rejects.toBe('P3 abort');
+      await expect(p2!).rejects.toBe('P2 abort during');
+    });
+    test('p3 = p1.finally(() => p2) - p3 cancellation chained to p1 cancellation propagates rejection', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => reject('P1 reject'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      let p2: PromiseCancellable<string>;
+      const p2Finally = jest.fn().mockImplementation((signal) => {
+        expect(signal.aborted).toBe(true);
+        p2 = new PromiseCancellable<string>((resolve, reject) => {
+          if (signal.aborted) {
+            reject('P2 abort beginning');
+            return;
+          }
+          const timeout = setTimeout(() => reject('P2 reject'), 100);
+          signal.onabort = () => {
+            clearTimeout(timeout);
+            reject('P2 abort during');
+          };
+        });
+        return p2;
+      });
+      const p3 = p1.finally(p2Finally, (signal) => {
+        signal.onabort = () => {
+          p1.cancel(signal.reason);
+        };
+      });
+      p3.cancel('P3 abort');
+      await expect(p3).rejects.toBe('P2 abort beginning');
+      await expect(p1).rejects.toBe('P1 abort');
+      expect(p2Finally).toBeCalledWith(expect.any(AbortSignal));
+      await expect(p2!).rejects.toBe('P2 abort beginning');
+    });
+  });
+  describe('PromiseCancellable.all', () => {
+    test('resolve regular values and promises', async () => {
+      const p = PromiseCancellable.all([
+        Promise.resolve(1),
+        PromiseCancellable.resolve(2),
+        3,
+        4
+      ]);
+      const results = await p;
+      expect(results).toStrictEqual([1, 2, 3, 4]);
+    });
+    test('rejecting promises', async () => {
+      const p1 = PromiseCancellable.all([
+        Promise.reject(1),
+        PromiseCancellable.resolve(2),
+        3,
+        4
+      ]);
+      await expect(p1).rejects.toBe(1);
+      const p2 = PromiseCancellable.all([
+        Promise.resolve(1),
+        PromiseCancellable.reject(2),
+        3,
+        4
+      ]);
+      await expect(p2).rejects.toBe(2);
+    });
+    test('rejection propagates', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject, signal) => {
+        const timeout = setTimeout(() => reject('P1 reject'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      const p2 = PromiseCancellable.all([
+        PromiseCancellable.all([
+          p1
+        ])
+      ]);
+      await expect(p2).rejects.toBe('P1 reject');
+    });
+    test('default cancellation is early rejection', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => resolve('P1 result'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      const p2 = PromiseCancellable.all([p1]);
+      p2.cancel('P2 abort');
+      await expect(p2).rejects.toBe('P2 abort');
+      await expect(p1).resolves.toBe('P1 result');
+    });
+    test('custom signal handler', async () => {
+      const abortController = new AbortController();
+      const p = PromiseCancellable.all([
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+      ], (signal) => {
+        signal.onabort = () => {
+          abortController.abort(signal.reason);
+        };
+      });
+      p.cancel('P abort');
+      await expect(p).rejects.toThrow('Aborted F');
+      await expect(p).rejects.toHaveProperty('cause', 'P abort');
+    });
+    test('custom abort controller', async () => {
+      const abortController = new AbortController();
+      const p = PromiseCancellable.all([
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+      ], abortController);
+      p.cancel('P abort');
+      await expect(p).rejects.toThrow('Aborted F');
+      await expect(p).rejects.toHaveProperty('cause', 'P abort');
+    });
+  });
+  describe('PromiseCancellable.allSettled', () => {
+    test('resolve regular values and promises', async () => {
+      const p = PromiseCancellable.allSettled([
+        Promise.resolve(1),
+        PromiseCancellable.resolve(2),
+        3,
+        4
+      ]);
+      const results = await p;
+      expect(results).toStrictEqual([
+        {
+          status: 'fulfilled',
+          value: 1
+        },
+        {
+          status: 'fulfilled',
+          value: 2
+        },
+        {
+          status: 'fulfilled',
+          value: 3
+        },
+        {
+          status: 'fulfilled',
+          value: 4
+        },
+      ]);
+    });
+    test('rejecting promises', async () => {
+      const p = PromiseCancellable.allSettled([
+        Promise.reject(1),
+        PromiseCancellable.reject(2),
+        3,
+        4
+      ]);
+      const results = await p;
+      expect(results).toStrictEqual([
+        {
+          status: 'rejected',
+          reason: 1
+        },
+        {
+          status: 'rejected',
+          reason: 2
+        },
+        {
+          status: 'fulfilled',
+          value: 3
+        },
+        {
+          status: 'fulfilled',
+          value: 4
+        },
+      ]);
+    });
+    test('rejection propagates', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject, signal) => {
+        const timeout = setTimeout(() => reject('P1 reject'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      const p2 = PromiseCancellable.allSettled([
+        PromiseCancellable.allSettled([
+          p1
+        ])
+      ]);
+      await expect(p2).resolves.toStrictEqual([{
+        status: 'fulfilled',
+        value: [{
+          status: 'rejected',
+          reason: 'P1 reject'
+        }]
+      }]);
+    });
+    test('default cancellation is early rejection', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => resolve('P1 result'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      const p2 = PromiseCancellable.allSettled([p1]);
+      p2.cancel('P2 abort');
+      await expect(p2).rejects.toBe('P2 abort');
+      await expect(p1).resolves.toBe('P1 result');
+    });
+    test('custom signal handler', async () => {
+      const abortController = new AbortController();
+      const p = PromiseCancellable.allSettled([
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+      ], (signal) => {
+        signal.onabort = () => {
+          abortController.abort(signal.reason);
+        };
+      });
+      p.cancel('P abort');
+      const results = await p;
+      expect(results).toMatchObject([
+        {
+          status: 'rejected',
+          reason: expect.objectContaining({
+            name: 'Error',
+            message: 'Aborted F',
+            cause: 'P abort'
+          })
+        },
+        {
+          status: 'rejected',
+          reason: expect.objectContaining({
+            name: 'Error',
+            message: 'Aborted F',
+            cause: 'P abort'
+          })
+        },
+        {
+          status: 'rejected',
+          reason: expect.objectContaining({
+            name: 'Error',
+            message: 'Aborted F',
+            cause: 'P abort'
+          })
+        },
+      ]);
+    });
+    test('custom abort controller', async () => {
+      const abortController = new AbortController();
+      const p = PromiseCancellable.allSettled([
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+      ], abortController);
+      p.cancel('P abort');
+      const results = await p;
+      expect(results).toMatchObject([
+        {
+          status: 'rejected',
+          reason: expect.objectContaining({
+            name: 'Error',
+            message: 'Aborted F',
+            cause: 'P abort'
+          })
+        },
+        {
+          status: 'rejected',
+          reason: expect.objectContaining({
+            name: 'Error',
+            message: 'Aborted F',
+            cause: 'P abort'
+          })
+        },
+        {
+          status: 'rejected',
+          reason: expect.objectContaining({
+            name: 'Error',
+            message: 'Aborted F',
+            cause: 'P abort'
+          })
+        },
+      ]);
+    });
+  });
+  describe('PromiseCancellable.race', () => {
+    test('resolve regular values and promises', async () => {
+      const p1 = PromiseCancellable.race([
+        Promise.resolve(1),
+        PromiseCancellable.resolve(2),
+        3,
+        4
+      ]);
+      expect([1,2,3,4]).toContain(await p1);
+      const p2 = PromiseCancellable.race([
+        new Promise((resolve) => setTimeout(() => resolve(1), 100)),
+        new Promise((resolve) => setTimeout(() => resolve(2), 50)),
+      ]);
+      await expect(p2).resolves.toBe(2);
+    });
+    test('rejecting promises', async () => {
+      const p1 = PromiseCancellable.race([
+        Promise.reject(1),
+        PromiseCancellable.reject(2),
+      ]);
+      await expect(p1).rejects.toBeDefined();
+      try {
+        await p1;
+      } catch (e) {
+        expect([1, 2]).toContain(e);
+      }
+      const p2 = PromiseCancellable.race([
+        new Promise((_resolve, reject) => setTimeout(() => reject(1), 100)),
+        new Promise((_resolve, reject) => setTimeout(() => reject(2), 50)),
+      ]);
+      await expect(p2).rejects.toBe(2);
+    });
+    test('rejection propagates', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject, signal) => {
+        const timeout = setTimeout(() => reject('P1 reject'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      const p2 = PromiseCancellable.race([
+        PromiseCancellable.race([
+          p1
+        ])
+      ]);
+      await expect(p2).rejects.toBe('P1 reject');
+    });
+    test('default cancellation is early rejection', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => resolve('P1 result'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      const p2 = PromiseCancellable.race([p1]);
+      p2.cancel('P2 abort');
+      await expect(p2).rejects.toBe('P2 abort');
+      await expect(p1).resolves.toBe('P1 result');
+    });
+    test('custom signal handler', async () => {
+      const abortController = new AbortController();
+      const p = PromiseCancellable.race([
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+      ], (signal) => {
+        signal.onabort = () => {
+          abortController.abort(signal.reason);
+        };
+      });
+      p.cancel('P abort');
+      await expect(p).rejects.toThrow('Aborted F');
+      await expect(p).rejects.toHaveProperty('cause', 'P abort');
+    });
+    test('custom abort controller', async () => {
+      const abortController = new AbortController();
+      const p = PromiseCancellable.race([
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+      ], abortController);
+      p.cancel('P abort');
+      await expect(p).rejects.toThrow('Aborted F');
+      await expect(p).rejects.toHaveProperty('cause', 'P abort');
+    });
+    test('racing signal handler', async () => {
+      const racer = jest.fn().mockImplementation((name: string, delay: number) => {
+        return new PromiseCancellable<string>((resolve, reject, signal) => {
+          if (signal.aborted) {
+            reject('racer abort beginning');
+            return;
+          }
+          const timeout = setTimeout(() => resolve(`racer ${name} result`), delay);
+          signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(timeout);
+              reject('racer abort during');
+            },
+            { once: true }
+          );
+        });
+      });
+      const race = [
+        racer('1', 50),
+        racer('2', 100),
+        racer('3', 150),
+      ];
+      const p = PromiseCancellable.race(race, (signal) => {
+        signal.onabort = () => {
+          race.map(r => r.cancel(signal.reason));
+        };
+      });
+      const result = await p;
+      p.cancel('P abort');
+      expect(result).toBe('racer 1 result');
+      await expect(race[1]).rejects.toBe('racer abort during');
+      await expect(race[2]).rejects.toBe('racer abort during');
+    });
+  });
+  describe('PromiseCancellable.any', () => {
+    test('resolve regular values and promises', async () => {
+      const p1 = PromiseCancellable.any([
+        Promise.resolve(1),
+        PromiseCancellable.resolve(2),
+        3,
+        Promise.reject(4)
+      ]);
+      const result = await p1;
+      expect([1,2,3]).toContain(result);
+      expect(result).not.toBe(4);
+      const p2 = PromiseCancellable.any([
+        new Promise((resolve) => setTimeout(() => resolve(1), 100)),
+        new Promise((resolve) => setTimeout(() => resolve(2), 50)),
+        new Promise((_resolve, reject) => setTimeout(() => reject(3), 25)),
+      ]);
+      await expect(p2).resolves.toBe(2);
+    });
+    test('rejecting promises', async () => {
+      const p1 = PromiseCancellable.any([
+        Promise.reject(1),
+        PromiseCancellable.reject(2),
+      ]);
+      await expect(p1).rejects.toThrow(AggregateError);
+      await expect(p1).rejects.toHaveProperty('errors', [1, 2]);
+      const p2 = PromiseCancellable.any([
+        new Promise((_resolve, reject) => setTimeout(() => reject(1), 100)),
+        new Promise((_resolve, reject) => setTimeout(() => reject(2), 50)),
+      ]);
+      await expect(p2).rejects.toThrow(AggregateError);
+      await expect(p2).rejects.toHaveProperty('errors', [1, 2]);
+    });
+    test('rejection propagates', async () => {
+      const p1 = new PromiseCancellable<string>((_resolve, reject, signal) => {
+        const timeout = setTimeout(() => reject('P1 reject'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      const p2 = PromiseCancellable.any([
+        PromiseCancellable.any([
+          p1
+        ])
+      ]);
+      await expect(p2).rejects.toThrow(AggregateError);
+      await expect(p2).rejects.toMatchObject({
+        errors: [
+          {
+            errors: ['P1 reject']
+          }
+        ]
+      });
+    });
+    test('default cancellation is early rejection', async () => {
+      const p1 = new PromiseCancellable<string>((resolve, reject, signal) => {
+        const timeout = setTimeout(() => resolve('P1 result'), 100);
+        signal.onabort = () => {
+          clearTimeout(timeout);
+          reject('P1 abort');
+        };
+      });
+      const p2 = PromiseCancellable.any([p1]);
+      p2.cancel('P2 abort');
+      await expect(p2).rejects.toBe('P2 abort');
+      await expect(p1).resolves.toBe('P1 result');
+    });
+    test('custom signal handler', async () => {
+      const abortController = new AbortController();
+      const p = PromiseCancellable.any([
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+      ], (signal) => {
+        signal.onabort = () => {
+          abortController.abort(signal.reason);
+        };
+      });
+      p.cancel('P abort');
+      await expect(p).rejects.toThrow(AggregateError);
+      await expect(p).rejects.toMatchObject({
+        errors: [
+          {
+            message: 'Aborted F',
+            cause: 'P abort'
+          },
+          {
+            message: 'Aborted F',
+            cause: 'P abort'
+          },
+          {
+            message: 'Aborted F',
+            cause: 'P abort'
+          }
+        ]
+      });
+    });
+    test('custom abort controller', async () => {
+      const abortController = new AbortController();
+      const p = PromiseCancellable.any([
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+        f({ signal: abortController.signal }),
+      ], abortController);
+      p.cancel('P abort');
+      await expect(p).rejects.toThrow(AggregateError);
+      await expect(p).rejects.toMatchObject({
+        errors: [
+          {
+            message: 'Aborted F',
+            cause: 'P abort'
+          },
+          {
+            message: 'Aborted F',
+            cause: 'P abort'
+          },
+          {
+            message: 'Aborted F',
+            cause: 'P abort'
+          }
+        ]
+      });
+    });
   });
 });

--- a/tests/PromiseCancellable.test.ts
+++ b/tests/PromiseCancellable.test.ts
@@ -14,6 +14,7 @@ describe(PromiseCancellable.name, () => {
             if (ctx.signal!.reason === undefined) {
               reject(new Error('Aborted F'));
             } else {
+              // @ts-ignore node supports cause property
               reject(new Error('Aborted F', { cause: ctx.signal!.reason }));
             }
           },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "module": "CommonJS",
-    "target": "ES2021",
+    "target": "ES2022",
     "baseUrl": "./src",
     "paths": {
       "@": ["index"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "module": "CommonJS",
-    "target": "ES2022",
+    "target": "ES2021",
     "baseUrl": "./src",
     "paths": {
       "@": ["index"],


### PR DESCRIPTION
### Description

The `PromiseCancellable` requires testing in cancellation behaviour and its behaviour in DAGs

### Issues Fixed

* Related https://github.com/MatrixAI/Polykey/issues/297

### Tasks

- [x] 1. Add tests for all instance and static methods
- [x] 2. Change to using the constructor as the main location for handling the default signal

### Final checklist

* [x] Domain specific tests
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Squash and rebased
* [x] Sanity check the final build
